### PR TITLE
Update style.css

### DIFF
--- a/familyGuy_practice_REV/css/style.css
+++ b/familyGuy_practice_REV/css/style.css
@@ -48,7 +48,6 @@ h2:hover{text-shadow: 0px 0px 0px rgb(0,0,0); }
 
 /* Classes*/
 .charBox {
-	float: left;
 	height: auto;
 }
 


### PR DESCRIPTION
I removed the rule float: left from the charBox class. This was causing <h2>Chris Griffin</h> to float up to the right of <h2>Peter Griffin</h2> when I hide the image / paragraph for both characters. Without float left on that class, all three <h2></h2> stay in place whether the content below them is visible or hidden.